### PR TITLE
Support Hasicorp Terraform files which have a .tf extension by default.

### DIFF
--- a/grammars/hcl.cson
+++ b/grammars/hcl.cson
@@ -4,7 +4,8 @@
 'scopeName': 'source.hcl'
 'name': 'HashiCorp Configuration Language'
 'fileTypes': [
-  'hcl'
+  'hcl',
+  'tf'
 ]
 'patterns': [
   {


### PR DESCRIPTION
Terraform uses HCL but uses the .tf extension, this minor change allows .tf files to be picked up by the package.
