### PR TITLE
Support block/multi-line comments

### DIFF
--- a/grammars/hcl.cson
+++ b/grammars/hcl.cson
@@ -122,7 +122,7 @@
     ]
 
   'comment':
-    'begin': '(^[ \\t]+)?(?=(#|//))'
+    'begin': '(^[ \\t]+)?(?=(#|//|/\\*))'
     'beginCaptures':
       '1':
         'name': 'punctuation.whitespace.comment.leading.hcl'
@@ -143,6 +143,17 @@
             'name': 'punctuation.definition.comment.hcl'
         'end': '\\n'
         'name': 'comment.line.pound.hcl'
+      }
+      {
+        'begin': '/\\*'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.hcl'
+        'end': '\\*/'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.hcl'
+        'name': 'comment.block.hcl'
       }
     ]
 


### PR DESCRIPTION
Implemented as [described](https://github.com/hashicorp/hcl#syntax):

> Multi-line comments are wrapped in /* and */. Nested block comments are not allowed. A multi-line comment (also known as a block comment) terminates at the first */ found.

Fixes #6 